### PR TITLE
Fixed iterator deprecation for PHP 8.1

### DIFF
--- a/src/Splitter.php
+++ b/src/Splitter.php
@@ -41,11 +41,11 @@ class Splitter implements IteratorAggregate
     /**
      * Iterator
      *
-     * @return array
+     * @return \Traversable
      */
-    public function getIterator(): array
+    public function getIterator(): \Traversable
     {
-        return $this->frames;
+        return new \ArrayIterator($this->frames);
     }
 
     public function getFrames(): array


### PR DESCRIPTION
I was getting this error with PHP 8.1:
```
PHP Deprecated:  Return type of Intervention\Gif\Splitter::getIterator(): array should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/deluxetom/Dev/dlxmedia/intervention-gif/src/Splitter.php on line 46
```

This PR fixes that deprecation error